### PR TITLE
Komoran 객체 생성 시 모델 지정이 필요하도록 변경

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -49,7 +49,7 @@
 
 ```python
   from PyKomoran import *
-  komoran = Komoran()
+  komoran = Komoran(DEFAULT_MODEL['LIGHT'])
 ```
 
 * After then, run analyzing method.
@@ -57,7 +57,7 @@
 ```python
   komoran.get_plain_text("① 대한민국은 민주공화국이다.")
   # # Result
-  # ①/SW 대한민국/NNP 은/JX 민주공화국/NNP 이/VCP 다/EF ./SF
+  # '①/SW 대한민국/NNP 은/JX 민주/NNP 공화국/NNG 이/VCP 다/EF ./SF'
 ```
 
 ### Usage in detail

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 
 ```python
   from PyKomoran import *
-  komoran = Komoran()
+  komoran = Komoran(DEFAULT_MODEL['LIGHT'])
 ```
 
 * 분석 메소드를 이용하여 문장을 분석합니다.
@@ -57,7 +57,7 @@
 ```python
   komoran.get_plain_text("① 대한민국은 민주공화국이다.")
   # # 실행 결과
-  # ①/SW 대한민국/NNP 은/JX 민주공화국/NNP 이/VCP 다/EF ./SF
+  # '①/SW 대한민국/NNP 은/JX 민주/NNP 공화국/NNG 이/VCP 다/EF ./SF'
 ```
 
 ### 자세한 사용법

--- a/docs/firststep/tutorial.rst
+++ b/docs/firststep/tutorial.rst
@@ -18,7 +18,7 @@
   :linenos:
 
   from PyKomoran import *
-  komoran = Komoran()
+  komoran = Komoran(DEFAULT_MODEL['FULL'])
   print(komoran.get_plain_text("KOMORAN은 한국어 형태소 분석기입니다."))
 
 실행 결과는 다음과 같습니다.
@@ -44,14 +44,23 @@ Python 명령어를 실행한 후, 다음과 같이 PyKomoran을 불러옵니다
 Komoran 객체 생성하기
 ---------------------------------------
 이제, 형태소 분석을 위한 ``Komoran`` 객체를 생성합니다.
+여기에서는 기본으로 제공하는 모델 중 FULL 모델을 불러오겠습니다.
 
 .. code-block:: python
   :linenos:
 
-  komoran = Komoran()
+  komoran = Komoran(DEFAULT_MODEL['FULL'])
 
 이 과정에서 Java 버전의 KOMORAN을 불러오게 되며, 약간의 시간이 소요됩니다.
 이제 ``Komoran`` 객체의 메소드를 이용하여 형태소를 분석할 수 있습니다.
+
+.. Note::
+  ``DEFAULT_MODEL`` 은 기본적으로 PyKomoran에 포함된 모델로, KOMORAN의 ``DEFAULT_MODEL`` 에 대응합니다.
+  즉, PyKOMORAN의 ``DEFAULT_MODEL['FULL']`` 과 ``DEFAULT_MODEL['LIGHT']`` 은 각각 KOMORAN의 ``DEFAULT_MODEL.FULL`` 과
+  ``DEFAULT_MODEL.LIGHT`` 에 대응합니다.
+
+.. TODO::
+  DFEAULT_MODEL에 대한 설명을 추가합니다.
 
 형태소 분석하기
 ---------------------------------------
@@ -80,7 +89,7 @@ PyKOMORAN은 KOMORAN에서 제공하는 다양한 형태의 형태소 분석 결
   from PyKomoran import *
 
   # Komoran 객체 생성
-  komoran = Komoran()
+  komoran = Komoran(DEFAULT_MODEL['FULL'])
 
   # 분석할 문장 준비
   str_to_analyze = "① 대한민국은 민주공화국이다. ② 대한민국의 주권은 국민에게 있고, 모든 권력은 국민으로부터 나온다."

--- a/python/PyKomoran/__init__.py
+++ b/python/PyKomoran/__init__.py
@@ -2,7 +2,7 @@ from .__version__ import __title__, __description__, __url__, __copyright__
 from .__version__ import __author__, __author_email__, __license__, __version__
 
 from .jvm import init_jvm
-from .type import Pair, Token, Pos
+from .type import Pair, Token, Pos, DEFAULT_MODEL
 from .core import Komoran
 
-__all__ = ['jvm', 'Pair', 'Token', 'Pos', 'Komoran']
+__all__ = ['jvm', 'Pair', 'Token', 'Pos', 'DEFAULT_MODEL', 'Komoran']

--- a/python/PyKomoran/__version__.py
+++ b/python/PyKomoran/__version__.py
@@ -8,7 +8,7 @@
 __title__ = 'PyKomoran'
 __description__ = 'PyKomoran is Python wrapper for KOMORAN, KOrean MORphical ANalyzer.'
 __url__ = 'https://pydocs.komoran.kr'
-__version__ = '0.1.2'
+__version__ = '0.1.3'
 __author__ = 'Junghwan Park'
 __author_email__ = 'reserve.dev@gmail.com'
 __license__ = 'Apache 2.0'

--- a/python/PyKomoran/tests/test_core.py
+++ b/python/PyKomoran/tests/test_core.py
@@ -15,7 +15,7 @@ def test_to_init_Komoran():
     """
     global komoran
 
-    komoran = Komoran(model_path='./models_full')
+    komoran = Komoran(DEFAULT_MODEL['FULL'])
 
     assert komoran is not None
     assert komoran._komoran.isInitialized()
@@ -306,7 +306,7 @@ def test_to_set_user_dic():
     global komoran
 
     if komoran is None:
-        komoran = Komoran(model_path='./models_full')
+        komoran = Komoran(DEFAULT_MODEL['FULL'])
 
     tokens = komoran.get_token_list("테스트 단어")
 
@@ -357,7 +357,7 @@ def test_to_set_fw_dic():
     global komoran
 
     if komoran is None:
-        komoran = Komoran(model_path='./models_full')
+        komoran = Komoran(DEFAULT_MODEL['FULL'])
 
     tokens = komoran.get_token_list("테스트")
 

--- a/python/PyKomoran/type.py
+++ b/python/PyKomoran/type.py
@@ -1,4 +1,6 @@
-__all__ = ['Token', 'Pair', 'Pos']
+import os
+
+__all__ = ['Token', 'Pair', 'Pos', 'DEFAULT_MODEL']
 
 
 class Token:
@@ -243,3 +245,30 @@ class Pos:
 
     def has_key(self, key):
         return key in self.pos_type
+
+
+class DefaultModel:
+    def __init__(self):
+        base_path = os.path.dirname(os.path.realpath(__file__))
+
+        self._models = {
+            'FULL': '{0}{1}models_full'.format(base_path, os.sep),
+            'LIGHT': "{0}{1}models_light".format(base_path, os.sep)
+        }
+
+    def __getitem__(self, model):
+        if model in self._models.keys():
+            return self._models[model]
+        else:
+            return ''
+
+    def __contains__(self, model):
+        return model in self._models
+
+    def __str__(self):
+        return str(self._models)
+
+    def __repr__(self):
+        return repr(self._models)
+
+DEFAULT_MODEL = DefaultModel()

--- a/python/README.md
+++ b/python/README.md
@@ -47,7 +47,7 @@
 
 ```python
   from PyKomoran import *
-  komoran = Komoran()
+  komoran = Komoran(DEFAULT_MODEL['LIGHT'])
 ```
 
 * After then, run analyzing method.
@@ -55,7 +55,7 @@
 ```python
   komoran.get_plain_text("① 대한민국은 민주공화국이다.")
   # # Result
-  # ①/SW 대한민국/NNP 은/JX 민주공화국/NNP 이/VCP 다/EF ./SF
+  # '①/SW 대한민국/NNP 은/JX 민주/NNP 공화국/NNG 이/VCP 다/EF ./SF'
 ```
 
 ### Usage in detail


### PR DESCRIPTION
#18 에 따라 Komoran 객체 생성 시 반드시 모델을 지정하도록 변경하였습니다.
(기존에는 Full 모델이 기본이었습니다.)

이는 KOMORAN에서도 동일하게 존재하였던 문제로,
사용자 사전 등의 적용 시 문제가 발생하는 것을 막기 위해 객체 생성 시 기본 모델을 지정하지 않습니다.