### PR TITLE
fix(py4j): Java 9+ 모듈 시스템 호환성 개선

### DIFF
--- a/python/PyKomoran/jvm.py
+++ b/python/PyKomoran/jvm.py
@@ -39,10 +39,17 @@ def init_jvm(max_heap=1024, jar_path="./libs"):
     classpath = os.pathsep.join([lib.format(jar_path, os.sep) for lib in libraries])
     py4j_path = "{0}{1}py4j-0.10.9.2.jar".format(jar_path, os.sep)
 
-    port = launch_gateway(jarpath=py4j_path,
-                          classpath=classpath,
-                          javaopts=['-Dfile.encoding=UTF8', '-ea', '-Xmx{}m'.format(max_heap)],
-                          die_on_exit=True)
+    port = launch_gateway(
+        jarpath=py4j_path,
+        classpath=classpath,
+        javaopts=[
+            '-Dfile.encoding=UTF8',
+            '-ea',
+            '-Xmx{}m'.format(max_heap),
+            '--add-opens', 'java.base/java.util=ALL-UNNAMED'
+        ],
+        die_on_exit=True
+    )
 
     logging.debug("initializing JVM... ")
     try:


### PR DESCRIPTION
### 문제
- Java 9+ 모듈 시스템에서 `java.util` 패키지 리플렉션 접근 차단
- `InaccessibleObjectException` 이 발생하여 List<> 내 요소를 가져오는데 실패하여 빈 리스트 []가 출력되는 현상 발생
- string을 return하는 get_plain_text는 영향 받지 않음

### 변경
- JVM 모듈 개방 옵션 추가

### 비고
- 테스트 환경 : macOS (Sequoia 15.4.1), Java (OpenJDK 17.0.15), Python (3.11.12)

## 관련 이슈 또는 PR 번호

#58 

## PR 종류

- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 문서 변경 (또는 문서 변경 필요)
- [x] 호환성 변경

## PR 설명

JDK 9+ 에서 get_token_list(), get_morphes_by_tags() 등의 함수의 결과가 []로 나오는 현상 수정

<img width="1030" alt="스크린샷 2025-04-20 03 40 07" src="https://github.com/user-attachments/assets/824a2d06-757d-469a-a358-92baf0ae7523" />
